### PR TITLE
Rename MainWindow

### DIFF
--- a/ShinyLog/ShinyLog/MainWindow.xaml
+++ b/ShinyLog/ShinyLog/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ShinyLog"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        Title="ShinyLog" Height="450" Width="800">
     <Grid>
 
     </Grid>


### PR DESCRIPTION
Renaming MainWindow to ShinyLog. Mostly meant for testing GitHub Actions